### PR TITLE
CentOS 8  not met requisites with EPEL

### DIFF
--- a/fia-installer-4l.sh
+++ b/fia-installer-4l.sh
@@ -185,7 +185,7 @@ if [[ -r /etc/os-release ]]; then
         
 	#Centos 8
 	if [[ $VERSION_ID = 8 ]]; then
-		dnf install fusioninventory-agent -y	
+		dnf --enablerepo=epel-testing install fusioninventory-agent fusioninventory-agent-task-inventory			
 	fi
 	
 		#Not installed?


### PR DESCRIPTION
Using Epel Testing as a workaround

Reference: https://github.com/fusioninventory/fusioninventory-agent/issues/727#issuecomment-625664805